### PR TITLE
Shortened representation of group elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/**
 .gradle/**
 out/**
+.idea/**

--- a/src/main/java/de/upb/crypto/math/pairings/mcl/MclGroup.java
+++ b/src/main/java/de/upb/crypto/math/pairings/mcl/MclGroup.java
@@ -24,18 +24,12 @@ public abstract class MclGroup implements Group {
         return new BigInteger("16798108731015832284940804142231733909759579603404752749028378864165570215949");
     }
 
-
-    @Override
-    public GroupElement getElement(Representation repr) {
-        return getElement(repr.str().get());
-    }
-
     protected abstract MclGroupElement getElement(String string);
 
     /**
-     * Outputs an object of type mcl.G1, mcl.G2, or mcl.GT
+     * Outputs an object of type mcl.G1, mcl.G2, or mcl.GT given its toString()
      */
-    protected abstract Object getEmptyInternalObject();
+    protected abstract Object getInternalObjectFromString(String str);
 
     @Override
     public Optional<Integer> getUniqueByteLength() {

--- a/src/main/java/de/upb/crypto/math/pairings/mcl/MclGroup1.java
+++ b/src/main/java/de/upb/crypto/math/pairings/mcl/MclGroup1.java
@@ -3,6 +3,7 @@ package de.upb.crypto.math.pairings.mcl;
 import com.herumi.mcl.Bn256;
 import com.herumi.mcl.Fr;
 import com.herumi.mcl.G1;
+import de.upb.crypto.math.interfaces.structures.GroupElement;
 import de.upb.crypto.math.interfaces.structures.PowProductExpression;
 import de.upb.crypto.math.random.interfaces.RandomGeneratorSupplier;
 import de.upb.crypto.math.serialization.Representation;
@@ -20,29 +21,28 @@ public class MclGroup1 extends MclGroup {
 
     @Override
     public MclGroup1Element getElement(String string) {
-        G1 res = new G1();
-        res.setStr(string);
-        return createElement(res);
+        return createElement(getInternalObjectFromString(string));
     }
 
     @Override
-    protected G1 getEmptyInternalObject() {
-        return new G1();
+    public GroupElement getElement(Representation repr) {
+        return new MclGroup1Element(this, repr);
+    }
+
+    @Override
+    protected G1 getInternalObjectFromString(String str) {
+        G1 res = new G1();
+        res.setStr(str);
+        return (G1) res;
     }
 
     protected MclGroup1Element createElement(G1 g1) {
         return new MclGroup1Element(this, g1);
     }
 
-    private MclGroup1Element createElement(String str) {
-        G1 result = new G1();
-        result.setStr(str);
-        return createElement(result);
-    }
-
     @Override
     public MclGroup1Element getNeutralElement() {
-        return createElement("0");
+        return getElement("0");
     }
 
     @Override

--- a/src/main/java/de/upb/crypto/math/pairings/mcl/MclGroup2.java
+++ b/src/main/java/de/upb/crypto/math/pairings/mcl/MclGroup2.java
@@ -3,6 +3,7 @@ package de.upb.crypto.math.pairings.mcl;
 import com.herumi.mcl.Bn256;
 import com.herumi.mcl.Fr;
 import com.herumi.mcl.G2;
+import de.upb.crypto.math.interfaces.structures.GroupElement;
 import de.upb.crypto.math.interfaces.structures.PowProductExpression;
 import de.upb.crypto.math.random.interfaces.RandomGeneratorSupplier;
 import de.upb.crypto.math.serialization.Representation;
@@ -20,29 +21,28 @@ public class MclGroup2 extends MclGroup {
 
     @Override
     public MclGroup2Element getElement(String string) {
-        G2 res = new G2();
-        res.setStr(string);
-        return createElement(res);
+        return createElement(getInternalObjectFromString(string));
     }
 
     @Override
-    protected G2 getEmptyInternalObject() {
-        return new G2();
+    public GroupElement getElement(Representation repr) {
+        return new MclGroup2Element(this, repr);
+    }
+
+    @Override
+    protected G2 getInternalObjectFromString(String str) {
+        G2 res = new G2();
+        res.setStr(str);
+        return (G2) res;
     }
 
     protected MclGroup2Element createElement(G2 G2) {
         return new MclGroup2Element(this, G2);
     }
 
-    private MclGroup2Element createElement(String str) {
-        G2 result = new G2();
-        result.setStr(str);
-        return createElement(result);
-    }
-
     @Override
     public MclGroup2Element getNeutralElement() {
-        return createElement("0");
+        return getElement("0");
     }
 
     @Override

--- a/src/main/java/de/upb/crypto/math/pairings/mcl/MclGroupElement.java
+++ b/src/main/java/de/upb/crypto/math/pairings/mcl/MclGroupElement.java
@@ -3,9 +3,9 @@ package de.upb.crypto.math.pairings.mcl;
 import de.upb.crypto.math.interfaces.hash.ByteAccumulator;
 import de.upb.crypto.math.interfaces.structures.Group;
 import de.upb.crypto.math.interfaces.structures.GroupElement;
-import de.upb.crypto.math.serialization.Representation;
-import de.upb.crypto.math.serialization.StringRepresentation;
+import de.upb.crypto.math.serialization.*;
 
+import java.math.BigInteger;
 import java.util.Objects;
 
 public abstract class MclGroupElement implements GroupElement {
@@ -18,7 +18,17 @@ public abstract class MclGroupElement implements GroupElement {
     }
 
     public MclGroupElement(MclGroup group, Representation repr) {
-        this(group, group.getElement(repr.str().get()));
+        StringBuilder sb = new StringBuilder();
+        boolean first = true;
+        for (Representation part : repr.list()) {
+            if (!first)
+                sb.append(" ");
+            sb.append(part.bigInt().get().toString());
+            first = false;
+        }
+
+        this.group = group;
+        this.element = group.getInternalObjectFromString(sb.toString());
     }
 
     /**
@@ -55,7 +65,12 @@ public abstract class MclGroupElement implements GroupElement {
 
     @Override
     public Representation getRepresentation() {
-        return new StringRepresentation(getElement().toString());
+        ListRepresentation result = new ListRepresentation();
+        String repr = getElement().toString(); //bunch of decimal numbers separated by spaces.
+        for (String str : repr.split(" "))
+            result.put(new BigIntegerRepresentation(new BigInteger(str)));
+
+        return result;
     }
 
     @Override

--- a/src/main/java/de/upb/crypto/math/pairings/mcl/MclGroupT.java
+++ b/src/main/java/de/upb/crypto/math/pairings/mcl/MclGroupT.java
@@ -19,29 +19,28 @@ public class MclGroupT extends MclGroup {
 
     @Override
     public MclGroupElement getElement(String string) {
-        GT res = new GT();
-        res.setStr(string);
-        return createElement(res);
+        return createElement(getInternalObjectFromString(string));
     }
 
     @Override
-    protected GT getEmptyInternalObject() {
-        return new GT();
+    public GroupElement getElement(Representation repr) {
+        return new MclGroupTElement(this, repr);
+    }
+
+    @Override
+    protected GT getInternalObjectFromString(String str) {
+        GT res = new GT();
+        res.setStr(str);
+        return (GT) res;
     }
 
     protected MclGroupTElement createElement(GT GT) {
         return new MclGroupTElement(this, GT);
     }
 
-    private MclGroupElement createElement(String str) {
-        GT result = new GT();
-        result.setStr(str);
-        return createElement(result);
-    }
-
     @Override
     public GroupElement getNeutralElement() {
-        return createElement("1 0 0 0 0 0 0 0 0 0 0 0");
+        return getElement("1 0 0 0 0 0 0 0 0 0 0 0");
     }
 
     @Override


### PR DESCRIPTION
Group elements are no longer opaquely represented as (decimal) strings, but instead as `BigIntegerRepresentation`s, which makes for shorter serializations.