### PR TITLE
Version bump mcl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Bumped version of mcl to `5faedff92a72a685d4e6c94e1974ec2033b9d352`
+
+## [2.0.0]
 
 ### Fixed
 
@@ -22,4 +26,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]: https://github.com/cryptimeleon/mclwrap/compare/v1.0.0...HEAD
 [1.0.0]: https://github.com/cryptimeleon/mclwrap/releases/tag/v1.0.0
-

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 group 'org.cryptimeleon'
 archivesBaseName = project.name
 boolean isRelease = project.hasProperty("release")
-version = '2.0.0'  + (isRelease ? "" : "-SNAPSHOT")
+version = '2.0.1'  + (isRelease ? "" : "-SNAPSHOT")
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
@@ -19,7 +19,6 @@ tasks.withType(JavaCompile) {
 repositories {
     mavenLocal()
     mavenCentral()
-    jcenter()
 }
 
 def mathVersionNoSuffix = '2.0.0'

--- a/install_mcl.sh
+++ b/install_mcl.sh
@@ -17,11 +17,14 @@ fi
 # check that JAVA_INC is given
 if [ $# -eq 0 ]; then
 	echo "Missing Java include argument"
-	echo "Please give path of Java include folder as first argument"
+	echo "Please specify path of your JDK 'include' directory as first argument"
 	if [ $os == "linux" ]; then
-    echo "For example: /usr/lib/jvm/java-8-openjdk-amd64/include"
+    echo "For example: ./install_mcl.sh /usr/lib/jvm/java-8-openjdk-amd64/include"
   else # mac os
-    echo "For example: /Library/Java/JavaVirtualMachines/openjdk-13.0.1.jdk/Contents/Home/include"
+    echo "For example: ./install_mcl.sh /Library/Java/JavaVirtualMachines/openjdk-13.0.1.jdk/Contents/Home/include"
+    echo "For your system, it's probably: "
+    javahome=$(/usr/libexec/java_home)
+    echo ./install_mcl.sh $javahome/include
   fi
 	exit 1
 fi

--- a/install_mcl.sh
+++ b/install_mcl.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-mcl_version="v1.28"
+mcl_version="5faedff92a72a685d4e6c94e1974ec2033b9d352"
 # exit immediately on error
 set -e
 
@@ -10,7 +10,7 @@ if [ "$(uname)" == "Darwin" ]; then
 elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
   os="linux"
 else
-  echo "Unsupported operating system. This script only works on Linux and Mac OS."
+  echo "Unsupported operating system. This script only works on Linux and macOS."
   exit 2
 fi
 

--- a/src/main/java/com/herumi/mcl/Fp.java
+++ b/src/main/java/com/herumi/mcl/Fp.java
@@ -64,6 +64,10 @@ public class Fp {
     return MclJNI.Fp_isZero(swigCPtr, this);
   }
 
+  public boolean isOne() {
+    return MclJNI.Fp_isOne(swigCPtr, this);
+  }
+
   public void setStr(String str, int base) {
     MclJNI.Fp_setStr__SWIG_0(swigCPtr, this, str, base);
   }

--- a/src/main/java/com/herumi/mcl/Fr.java
+++ b/src/main/java/com/herumi/mcl/Fr.java
@@ -64,6 +64,10 @@ public class Fr {
     return MclJNI.Fr_isZero(swigCPtr, this);
   }
 
+  public boolean isOne() {
+    return MclJNI.Fr_isOne(swigCPtr, this);
+  }
+
   public void setStr(String str, int base) {
     MclJNI.Fr_setStr__SWIG_0(swigCPtr, this, str, base);
   }
@@ -94,6 +98,14 @@ public class Fr {
 
   public void deserialize(byte[] cbuf) {
     MclJNI.Fr_deserialize(swigCPtr, this, cbuf);
+  }
+
+  public void setLittleEndianMod(byte[] cbuf) {
+    MclJNI.Fr_setLittleEndianMod(swigCPtr, this, cbuf);
+  }
+
+  public void setHashOf(byte[] cbuf) {
+    MclJNI.Fr_setHashOf(swigCPtr, this, cbuf);
   }
 
   public byte[] serialize() { return MclJNI.Fr_serialize(swigCPtr, this); }

--- a/src/main/java/com/herumi/mcl/G1.java
+++ b/src/main/java/com/herumi/mcl/G1.java
@@ -56,6 +56,10 @@ public class G1 {
     return MclJNI.G1_isZero(swigCPtr, this);
   }
 
+  public boolean isValidOrder() {
+    return MclJNI.G1_isValidOrder(swigCPtr, this);
+  }
+
   public void set(Fp x, Fp y) {
     MclJNI.G1_set(swigCPtr, this, Fp.getCPtr(x), x, Fp.getCPtr(y), y);
   }
@@ -85,5 +89,25 @@ public class G1 {
   }
 
   public byte[] serialize() { return MclJNI.G1_serialize(swigCPtr, this); }
+
+  public void normalize() {
+    MclJNI.G1_normalize(swigCPtr, this);
+  }
+
+  public void tryAndIncMapTo(Fp x) {
+    MclJNI.G1_tryAndIncMapTo(swigCPtr, this, Fp.getCPtr(x), x);
+  }
+
+  public Fp getX() {
+    return new Fp(MclJNI.G1_getX(swigCPtr, this), true);
+  }
+
+  public Fp getY() {
+    return new Fp(MclJNI.G1_getY(swigCPtr, this), true);
+  }
+
+  public Fp getZ() {
+    return new Fp(MclJNI.G1_getZ(swigCPtr, this), true);
+  }
 
 }

--- a/src/main/java/com/herumi/mcl/G2.java
+++ b/src/main/java/com/herumi/mcl/G2.java
@@ -86,4 +86,8 @@ public class G2 {
 
   public byte[] serialize() { return MclJNI.G2_serialize(swigCPtr, this); }
 
+  public void normalize() {
+    MclJNI.G2_normalize(swigCPtr, this);
+  }
+
 }

--- a/src/main/java/com/herumi/mcl/Mcl.java
+++ b/src/main/java/com/herumi/mcl/Mcl.java
@@ -17,6 +17,10 @@ public class Mcl implements MclConstants {
     MclJNI.neg__SWIG_0(Fr.getCPtr(y), y, Fr.getCPtr(x), x);
   }
 
+  public static void inv(Fr y, Fr x) {
+    MclJNI.inv__SWIG_0(Fr.getCPtr(y), y, Fr.getCPtr(x), x);
+  }
+
   public static void add(Fr z, Fr x, Fr y) {
     MclJNI.add__SWIG_0(Fr.getCPtr(z), z, Fr.getCPtr(x), x, Fr.getCPtr(y), y);
   }
@@ -47,6 +51,10 @@ public class Mcl implements MclConstants {
 
   public static void neg(Fp y, Fp x) {
     MclJNI.neg__SWIG_1(Fp.getCPtr(y), y, Fp.getCPtr(x), x);
+  }
+
+  public static void inv(Fp y, Fp x) {
+    MclJNI.inv__SWIG_1(Fp.getCPtr(y), y, Fp.getCPtr(x), x);
   }
 
   public static void add(Fp z, Fp x, Fp y) {
@@ -114,7 +122,7 @@ public class Mcl implements MclConstants {
   }
 
   public static void inv(GT y, GT x) {
-    MclJNI.inv(GT.getCPtr(y), y, GT.getCPtr(x), x);
+    MclJNI.inv__SWIG_2(GT.getCPtr(y), y, GT.getCPtr(x), x);
   }
 
 }

--- a/src/main/java/com/herumi/mcl/MclConstants.java
+++ b/src/main/java/com/herumi/mcl/MclConstants.java
@@ -11,4 +11,5 @@ package com.herumi.mcl;
 public interface MclConstants {
   public final static int BN254 = 0;
   public final static int BLS12_381 = 5;
+  public final static int SECP256K1 = 102;
 }

--- a/src/main/java/com/herumi/mcl/MclJNI.java
+++ b/src/main/java/com/herumi/mcl/MclJNI.java
@@ -11,6 +11,7 @@ package com.herumi.mcl;
 public class MclJNI {
   public final static native void SystemInit(int jarg1);
   public final static native void neg__SWIG_0(long jarg1, Fr jarg1_, long jarg2, Fr jarg2_);
+  public final static native void inv__SWIG_0(long jarg1, Fr jarg1_, long jarg2, Fr jarg2_);
   public final static native void add__SWIG_0(long jarg1, Fr jarg1_, long jarg2, Fr jarg2_, long jarg3, Fr jarg3_);
   public final static native void sub__SWIG_0(long jarg1, Fr jarg1_, long jarg2, Fr jarg2_, long jarg3, Fr jarg3_);
   public final static native void mul__SWIG_0(long jarg1, Fr jarg1_, long jarg2, Fr jarg2_, long jarg3, Fr jarg3_);
@@ -25,6 +26,7 @@ public class MclJNI {
   public final static native long new_Fr__SWIG_4(String jarg1);
   public final static native boolean Fr_equals(long jarg1, Fr jarg1_, long jarg2, Fr jarg2_);
   public final static native boolean Fr_isZero(long jarg1, Fr jarg1_);
+  public final static native boolean Fr_isOne(long jarg1, Fr jarg1_);
   public final static native void Fr_setStr__SWIG_0(long jarg1, Fr jarg1_, String jarg2, int jarg3);
   public final static native void Fr_setStr__SWIG_1(long jarg1, Fr jarg1_, String jarg2);
   public final static native void Fr_setInt(long jarg1, Fr jarg1_, int jarg2);
@@ -33,9 +35,12 @@ public class MclJNI {
   public final static native String Fr_toString__SWIG_0(long jarg1, Fr jarg1_, int jarg2);
   public final static native String Fr_toString__SWIG_1(long jarg1, Fr jarg1_);
   public final static native void Fr_deserialize(long jarg1, Fr jarg1_, byte[] jarg2);
+  public final static native void Fr_setLittleEndianMod(long jarg1, Fr jarg1_, byte[] jarg2);
+  public final static native void Fr_setHashOf(long jarg1, Fr jarg1_, byte[] jarg2);
   public final static native byte[] Fr_serialize(long jarg1, Fr jarg1_);
   public final static native void delete_Fr(long jarg1);
   public final static native void neg__SWIG_1(long jarg1, Fp jarg1_, long jarg2, Fp jarg2_);
+  public final static native void inv__SWIG_1(long jarg1, Fp jarg1_, long jarg2, Fp jarg2_);
   public final static native void add__SWIG_1(long jarg1, Fp jarg1_, long jarg2, Fp jarg2_, long jarg3, Fp jarg3_);
   public final static native void sub__SWIG_1(long jarg1, Fp jarg1_, long jarg2, Fp jarg2_, long jarg3, Fp jarg3_);
   public final static native void mul__SWIG_3(long jarg1, Fp jarg1_, long jarg2, Fp jarg2_, long jarg3, Fp jarg3_);
@@ -47,6 +52,7 @@ public class MclJNI {
   public final static native long new_Fp__SWIG_4(String jarg1);
   public final static native boolean Fp_equals(long jarg1, Fp jarg1_, long jarg2, Fp jarg2_);
   public final static native boolean Fp_isZero(long jarg1, Fp jarg1_);
+  public final static native boolean Fp_isOne(long jarg1, Fp jarg1_);
   public final static native void Fp_setStr__SWIG_0(long jarg1, Fp jarg1_, String jarg2, int jarg3);
   public final static native void Fp_setStr__SWIG_1(long jarg1, Fp jarg1_, String jarg2);
   public final static native void Fp_setInt(long jarg1, Fp jarg1_, int jarg2);
@@ -68,6 +74,7 @@ public class MclJNI {
   public final static native long new_G1__SWIG_2(long jarg1, Fp jarg1_, long jarg2, Fp jarg2_);
   public final static native boolean G1_equals(long jarg1, G1 jarg1_, long jarg2, G1 jarg2_);
   public final static native boolean G1_isZero(long jarg1, G1 jarg1_);
+  public final static native boolean G1_isValidOrder(long jarg1, G1 jarg1_);
   public final static native void G1_set(long jarg1, G1 jarg1_, long jarg2, Fp jarg2_, long jarg3, Fp jarg3_);
   public final static native void G1_clear(long jarg1, G1 jarg1_);
   public final static native void G1_setStr__SWIG_0(long jarg1, G1 jarg1_, String jarg2, int jarg3);
@@ -76,6 +83,11 @@ public class MclJNI {
   public final static native String G1_toString__SWIG_1(long jarg1, G1 jarg1_);
   public final static native void G1_deserialize(long jarg1, G1 jarg1_, byte[] jarg2);
   public final static native byte[] G1_serialize(long jarg1, G1 jarg1_);
+  public final static native void G1_normalize(long jarg1, G1 jarg1_);
+  public final static native void G1_tryAndIncMapTo(long jarg1, G1 jarg1_, long jarg2, Fp jarg2_);
+  public final static native long G1_getX(long jarg1, G1 jarg1_);
+  public final static native long G1_getY(long jarg1, G1 jarg1_);
+  public final static native long G1_getZ(long jarg1, G1 jarg1_);
   public final static native void delete_G1(long jarg1);
   public final static native void neg__SWIG_3(long jarg1, G2 jarg1_, long jarg2, G2 jarg2_);
   public final static native void dbl__SWIG_1(long jarg1, G2 jarg1_, long jarg2, G2 jarg2_);
@@ -95,9 +107,10 @@ public class MclJNI {
   public final static native String G2_toString__SWIG_1(long jarg1, G2 jarg1_);
   public final static native void G2_deserialize(long jarg1, G2 jarg1_, byte[] jarg2);
   public final static native byte[] G2_serialize(long jarg1, G2 jarg1_);
+  public final static native void G2_normalize(long jarg1, G2 jarg1_);
   public final static native void delete_G2(long jarg1);
   public final static native void mul__SWIG_4(long jarg1, GT jarg1_, long jarg2, GT jarg2_, long jarg3, GT jarg3_);
-  public final static native void inv(long jarg1, GT jarg1_, long jarg2, GT jarg2_);
+  public final static native void inv__SWIG_2(long jarg1, GT jarg1_, long jarg2, GT jarg2_);
   public final static native long new_GT__SWIG_0();
   public final static native long new_GT__SWIG_1(long jarg1, GT jarg1_);
   public final static native boolean GT_equals(long jarg1, GT jarg1_, long jarg2, GT jarg2_);


### PR DESCRIPTION
Using a newer version of mcl (newest _release_ (v1.51) had test errors, so I've referenced the current mcl `master` branch commit). 

It works on my (macOS) machine. 

Can you please test `./install_mcl.sh` on your machines, @rheitjoh , @feidens ?