### PR TITLE
Enable subgroup checks for G1 and G2 via verifyOrder

### DIFF
--- a/install_mcl.sh
+++ b/install_mcl.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-mcl_version="v1.28"
+#mcl_version="v1.28"
+mcl_version="5faedff92a72a685d4e6c94e1974ec2033b9d352"
 # exit immediately on error
 set -e
 

--- a/src/main/java/com/herumi/mcl/Mcl.java
+++ b/src/main/java/com/herumi/mcl/Mcl.java
@@ -17,6 +17,10 @@ public class Mcl implements MclConstants {
     MclJNI.neg__SWIG_0(Fr.getCPtr(y), y, Fr.getCPtr(x), x);
   }
 
+  public static void inv(Fr y, Fr x) {
+    MclJNI.inv__SWIG_0(Fr.getCPtr(y), y, Fr.getCPtr(x), x);
+  }
+
   public static void add(Fr z, Fr x, Fr y) {
     MclJNI.add__SWIG_0(Fr.getCPtr(z), z, Fr.getCPtr(x), x, Fr.getCPtr(y), y);
   }
@@ -47,6 +51,10 @@ public class Mcl implements MclConstants {
 
   public static void neg(Fp y, Fp x) {
     MclJNI.neg__SWIG_1(Fp.getCPtr(y), y, Fp.getCPtr(x), x);
+  }
+
+  public static void inv(Fp y, Fp x) {
+    MclJNI.inv__SWIG_1(Fp.getCPtr(y), y, Fp.getCPtr(x), x);
   }
 
   public static void add(Fp z, Fp x, Fp y) {
@@ -114,7 +122,15 @@ public class Mcl implements MclConstants {
   }
 
   public static void inv(GT y, GT x) {
-    MclJNI.inv(GT.getCPtr(y), y, GT.getCPtr(x), x);
+    MclJNI.inv__SWIG_2(GT.getCPtr(y), y, GT.getCPtr(x), x);
+  }
+
+  public static void verifyOrderG1(boolean doVerify) {
+    MclJNI.verifyOrderG1(doVerify);
+  }
+
+  public static void verifyOrderG2(boolean doVerify) {
+    MclJNI.verifyOrderG2(doVerify);
   }
 
 }

--- a/src/main/java/com/herumi/mcl/MclJNI.java
+++ b/src/main/java/com/herumi/mcl/MclJNI.java
@@ -11,6 +11,7 @@ package com.herumi.mcl;
 public class MclJNI {
   public final static native void SystemInit(int jarg1);
   public final static native void neg__SWIG_0(long jarg1, Fr jarg1_, long jarg2, Fr jarg2_);
+  public final static native void inv__SWIG_0(long jarg1, Fr jarg1_, long jarg2, Fr jarg2_);
   public final static native void add__SWIG_0(long jarg1, Fr jarg1_, long jarg2, Fr jarg2_, long jarg3, Fr jarg3_);
   public final static native void sub__SWIG_0(long jarg1, Fr jarg1_, long jarg2, Fr jarg2_, long jarg3, Fr jarg3_);
   public final static native void mul__SWIG_0(long jarg1, Fr jarg1_, long jarg2, Fr jarg2_, long jarg3, Fr jarg3_);
@@ -25,6 +26,7 @@ public class MclJNI {
   public final static native long new_Fr__SWIG_4(String jarg1);
   public final static native boolean Fr_equals(long jarg1, Fr jarg1_, long jarg2, Fr jarg2_);
   public final static native boolean Fr_isZero(long jarg1, Fr jarg1_);
+  public final static native boolean Fr_isOne(long jarg1, Fr jarg1_);
   public final static native void Fr_setStr__SWIG_0(long jarg1, Fr jarg1_, String jarg2, int jarg3);
   public final static native void Fr_setStr__SWIG_1(long jarg1, Fr jarg1_, String jarg2);
   public final static native void Fr_setInt(long jarg1, Fr jarg1_, int jarg2);
@@ -33,9 +35,12 @@ public class MclJNI {
   public final static native String Fr_toString__SWIG_0(long jarg1, Fr jarg1_, int jarg2);
   public final static native String Fr_toString__SWIG_1(long jarg1, Fr jarg1_);
   public final static native void Fr_deserialize(long jarg1, Fr jarg1_, byte[] jarg2);
+  public final static native void Fr_setLittleEndianMod(long jarg1, Fr jarg1_, byte[] jarg2);
+  public final static native void Fr_setHashOf(long jarg1, Fr jarg1_, byte[] jarg2);
   public final static native byte[] Fr_serialize(long jarg1, Fr jarg1_);
   public final static native void delete_Fr(long jarg1);
   public final static native void neg__SWIG_1(long jarg1, Fp jarg1_, long jarg2, Fp jarg2_);
+  public final static native void inv__SWIG_1(long jarg1, Fp jarg1_, long jarg2, Fp jarg2_);
   public final static native void add__SWIG_1(long jarg1, Fp jarg1_, long jarg2, Fp jarg2_, long jarg3, Fp jarg3_);
   public final static native void sub__SWIG_1(long jarg1, Fp jarg1_, long jarg2, Fp jarg2_, long jarg3, Fp jarg3_);
   public final static native void mul__SWIG_3(long jarg1, Fp jarg1_, long jarg2, Fp jarg2_, long jarg3, Fp jarg3_);
@@ -47,6 +52,7 @@ public class MclJNI {
   public final static native long new_Fp__SWIG_4(String jarg1);
   public final static native boolean Fp_equals(long jarg1, Fp jarg1_, long jarg2, Fp jarg2_);
   public final static native boolean Fp_isZero(long jarg1, Fp jarg1_);
+  public final static native boolean Fp_isOne(long jarg1, Fp jarg1_);
   public final static native void Fp_setStr__SWIG_0(long jarg1, Fp jarg1_, String jarg2, int jarg3);
   public final static native void Fp_setStr__SWIG_1(long jarg1, Fp jarg1_, String jarg2);
   public final static native void Fp_setInt(long jarg1, Fp jarg1_, int jarg2);
@@ -68,6 +74,7 @@ public class MclJNI {
   public final static native long new_G1__SWIG_2(long jarg1, Fp jarg1_, long jarg2, Fp jarg2_);
   public final static native boolean G1_equals(long jarg1, G1 jarg1_, long jarg2, G1 jarg2_);
   public final static native boolean G1_isZero(long jarg1, G1 jarg1_);
+  public final static native boolean G1_isValidOrder(long jarg1, G1 jarg1_);
   public final static native void G1_set(long jarg1, G1 jarg1_, long jarg2, Fp jarg2_, long jarg3, Fp jarg3_);
   public final static native void G1_clear(long jarg1, G1 jarg1_);
   public final static native void G1_setStr__SWIG_0(long jarg1, G1 jarg1_, String jarg2, int jarg3);
@@ -76,6 +83,11 @@ public class MclJNI {
   public final static native String G1_toString__SWIG_1(long jarg1, G1 jarg1_);
   public final static native void G1_deserialize(long jarg1, G1 jarg1_, byte[] jarg2);
   public final static native byte[] G1_serialize(long jarg1, G1 jarg1_);
+  public final static native void G1_normalize(long jarg1, G1 jarg1_);
+  public final static native void G1_tryAndIncMapTo(long jarg1, G1 jarg1_, long jarg2, Fp jarg2_);
+  public final static native long G1_getX(long jarg1, G1 jarg1_);
+  public final static native long G1_getY(long jarg1, G1 jarg1_);
+  public final static native long G1_getZ(long jarg1, G1 jarg1_);
   public final static native void delete_G1(long jarg1);
   public final static native void neg__SWIG_3(long jarg1, G2 jarg1_, long jarg2, G2 jarg2_);
   public final static native void dbl__SWIG_1(long jarg1, G2 jarg1_, long jarg2, G2 jarg2_);
@@ -95,9 +107,10 @@ public class MclJNI {
   public final static native String G2_toString__SWIG_1(long jarg1, G2 jarg1_);
   public final static native void G2_deserialize(long jarg1, G2 jarg1_, byte[] jarg2);
   public final static native byte[] G2_serialize(long jarg1, G2 jarg1_);
+  public final static native void G2_normalize(long jarg1, G2 jarg1_);
   public final static native void delete_G2(long jarg1);
   public final static native void mul__SWIG_4(long jarg1, GT jarg1_, long jarg2, GT jarg2_, long jarg3, GT jarg3_);
-  public final static native void inv(long jarg1, GT jarg1_, long jarg2, GT jarg2_);
+  public final static native void inv__SWIG_2(long jarg1, GT jarg1_, long jarg2, GT jarg2_);
   public final static native long new_GT__SWIG_0();
   public final static native long new_GT__SWIG_1(long jarg1, GT jarg1_);
   public final static native boolean GT_equals(long jarg1, GT jarg1_, long jarg2, GT jarg2_);
@@ -110,4 +123,6 @@ public class MclJNI {
   public final static native void GT_deserialize(long jarg1, GT jarg1_, byte[] jarg2);
   public final static native byte[] GT_serialize(long jarg1, GT jarg1_);
   public final static native void delete_GT(long jarg1);
+  public final static native void verifyOrderG1(boolean jarg1);
+  public final static native void verifyOrderG2(boolean jarg1);
 }

--- a/src/main/java/org/cryptimeleon/mclwrap/bn254/MclBilinearGroupImpl.java
+++ b/src/main/java/org/cryptimeleon/mclwrap/bn254/MclBilinearGroupImpl.java
@@ -59,7 +59,7 @@ class MclBilinearGroupImpl implements BilinearGroupImpl {
                 return;
             }
             try {
-                // TODO: DO we want to offer the other curve type too?
+                // only offer BN254, offering both difficult since it is done statically inside Mcl
                 Mcl.SystemInit(Mcl.BN254);
             } catch (UnsatisfiedLinkError le) {
                 if (printError) {
@@ -68,6 +68,8 @@ class MclBilinearGroupImpl implements BilinearGroupImpl {
                 }
                 return;
             }
+            Mcl.verifyOrderG1(true);
+            Mcl.verifyOrderG2(true);
             isInitialized = true;
             g1 = new MclGroup1Impl();
             g2 = new MclGroup2Impl();

--- a/src/test/java/org/cryptimeleon/mclwrap/bn254/MembershipTest.java
+++ b/src/test/java/org/cryptimeleon/mclwrap/bn254/MembershipTest.java
@@ -1,0 +1,31 @@
+package org.cryptimeleon.mclwrap.bn254;
+
+import org.cryptimeleon.math.serialization.BigIntegerRepresentation;
+import org.cryptimeleon.math.serialization.ListRepresentation;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+
+
+public class MembershipTest {
+    @Test
+    public void testOnCurve() {
+        MclBilinearGroupImpl bilGroupImpl = new MclBilinearGroupImpl();
+        MclGroup2Impl groupG2Impl = bilGroupImpl.getG2();
+        BigInteger[] coords = new BigInteger[5];
+        coords[0] = new BigInteger("1");
+        coords[1] = new BigInteger("10599278435418681622810665769941266812667319675599408820180893057347165702478");
+        coords[2] = new BigInteger("5582223682282056256096077371797887602975186621861422240082223070902431790978");
+        coords[3] = new BigInteger("15460700595750929643941411310687174139843649931729260652222255335996967235678");
+        coords[4] = new BigInteger("16696288540357646523389079979160608706340150042719992903313950531521707534741");
+        coords[1] = coords[1].add(BigInteger.ONE);
+        ListRepresentation newListRepr = new ListRepresentation();
+        for (BigInteger bigInt : coords) {
+            newListRepr.add(new BigIntegerRepresentation(bigInt));
+        }
+        Assertions.assertThrows(RuntimeException.class, () -> {
+            new MclGroup2ElementImpl(groupG2Impl, newListRepr);
+        });
+    }
+}


### PR DESCRIPTION
Addresses #28 by adding `verifyOrderG1` and `verifyOrderG2` to the FFI and enabling them after Mcl initialization. This means that subgroup checks are automatically done when using the `setStr` method which we use for deserialization.

Is missing checks for GT since Mcl has no `verifyOrder` method for that.