### PR TITLE
Enable additional performance optimization options for libmcljava

### DIFF
--- a/.github/workflows/dev-ci.yaml
+++ b/.github/workflows/dev-ci.yaml
@@ -15,7 +15,11 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-      - name: Install Mcl Java bindings
+      - name: Install Mcl Java bindings without custom GMP
         run: ./scripts/install_fast_mcljava_linux_mac.sh $JAVA_HOME/include
       - name: Build with Gradle
+        run: ./gradlew build -PcheckoutIfCloned
+      - name: Istall Mcl Java bindings with custom GMP
+        run: ./scripts/install_fast_mcljava_linux_mac.sh $JAVA_HOME/include gmp
+      - name: Build with Gradle again
         run: ./gradlew build -PcheckoutIfCloned

--- a/README.md
+++ b/README.md
@@ -62,12 +62,14 @@ This is optional, but strongly recommended for full performance on modern CPUs.
 
 You can peform most of the installation automatically by using the [scripts/install_fast_mcljava_linux_mac.sh](scripts/install_fast_mcljava_linux_mac.sh) script contained in this repository. 
 It will compile the mcl library (version v1.28) as well as the Java bindings, and move the shared library to the correct library folder.
-As a prerequisite, you need to have the `libgmp-dev` package (i.e. libgmp and the corresponding headers) installed. You can also run the script with an arbitrary second parameter in order to download and compile gmp from source and install it to /usr/local/{include,lib} for future use.
+As a prerequisite, you need to have the `libgmp-dev` package (i.e. libgmp and the corresponding headers) installed. You can also run the [install_mcljava_with_optimized_gmp.sh](scripts/install_mcljava_with_optimized_gmp.sh) script with an arbitrary second parameter in order to download and compile gmp from source and install it to /usr/local/{include,lib} for future use.
 You will also need `make` and `g++` (or `clang++` if using FreeBSD or OpenBSD).
 
 The [scripts/install_fast_mcljava_linux_mac.sh](scripts/install_fast_mcljava_linux_mac.sh) script takes the `include` path of your Java JDK as its only argument. 
 The path should be given without a trailing forward slash.  
-The created binary library is optimized for the specific CPU model the script was executed on and **might not work** on other, even very similar, CPUs. If you want the created library to be portable to other machines, use the scripts whose names contain "portable".
+The created binary library is optimized for roughly the CPU model and operating system version the script was executed on and **might not work** on other CPUs and system versions. If you want the created library to be portable to other machines, use the scripts whose names contain "portable".
+
+Finally, the [install_mcljava_with_optimized_gmp.sh](scripts/install_mcljava_with_optimized_gmp.sh) script takes the same `include` paramter, but tries to link against an existing or compiles an optimized libgmp to or from /usr/locale/lib. On some systems, especially older CPUs running Linux, this can achieve additional performance compared to the install_fast_mcljava_linux_mac.sh script, while on other systems the resulting library is slower.
 
 ## Compiling mcl on Windows
 This is optional, but strongly recommended for full performance on modern CPUs.

--- a/README.md
+++ b/README.md
@@ -62,11 +62,12 @@ This is optional, but strongly recommended for full performance on modern CPUs.
 
 You can peform most of the installation automatically by using the [scripts/install_fast_mcljava_linux_mac.sh](scripts/install_fast_mcljava_linux_mac.sh) script contained in this repository. 
 It will compile the mcl library (version v1.28) as well as the Java bindings, and move the shared library to the correct library folder.
-As a prerequisite, you need to have the `libgmp-dev` package (i.e. libgmp and the corresponding headers) installed.
+As a prerequisite, you need to have the `libgmp-dev` package (i.e. libgmp and the corresponding headers) installed. You can also run the script with an arbitrary second parameter in order to download and compile gmp from source and install it to /usr/local/{include,lib} for future use.
 You will also need `make` and `g++` (or `clang++` if using FreeBSD or OpenBSD).
 
 The [scripts/install_fast_mcljava_linux_mac.sh](scripts/install_fast_mcljava_linux_mac.sh) script takes the `include` path of your Java JDK as its only argument. 
-The path should be given without a trailing forward slash.
+The path should be given without a trailing forward slash.  
+The created binary library is optimized for the specific CPU model the script was executed on and **might not work** on other, even very similar, CPUs. If you want the created library to be portable to other machines, use the scripts whose names contain "portable".
 
 ## Compiling mcl on Windows
 This is optional, but strongly recommended for full performance on modern CPUs.

--- a/scripts/install_fast_mcljava_linux_mac.sh
+++ b/scripts/install_fast_mcljava_linux_mac.sh
@@ -1,68 +1,25 @@
-#!/usr/bin/env sh
-mcl_version="ae1c67a819a81fd645a544d5fb420b980b89816a"
+#!/usr/bin/env bash
+mcl_version="v1.52"
 # exit immediately on error
 set -e
 
-C_TUNING_FLAGS="-march=native -mtune=native"
-
-arch="$(uname -m)"
-
-if [ "$arch" = "arm64" ] || [ "$arch" = "aarch64" ]; then
-  if command -v clang &>/dev/null; then
-    # clang exists and we run on arm64 - clang might be chosen as compiler by CMake, and on this arch, it does not support -march=native
-    # this flag works with both gcc and clang on aarch64, however, and should have the same effect - use it instead
-    C_TUNING_FLAGS="-mcpu=native"
-  fi
-fi
-
-GMP_VERSION=6.2.1
-gmp_from_source(){
- echo "Cloning GNU gmp."
- curl https://gmplib.org/download/gmp/gmp-${GMP_VERSION}.tar.xz > gmp-${GMP_VERSION}.tar.xz || (echo "Error downloading GMP" && exit 1)
- unxz gmp-${GMP_VERSION}.tar.xz || (echo "Could not extract .xz archive - make sure you have unxz installed." && exit 1)
- tar -xvf gmp-${GMP_VERSION}.tar || (echo "Could not untar the gmp tree." && exit 1)
- rm gmp-${GMP_VERSION}.tar
- cd gmp-${GMP_VERSION}
- ./configure --enable-shared --enable-static --enable-cxx || (echo "Could not determine a GMP configuration" && exit 1)
- MAKE_PARALLEL=""
- if command -v nproc &>/dev/null; then
-	 MAKA_PARALLEL="-j $(nproc)"
- else
-	 echo "nproc was not found on your system - defaulting to default make behavior (usually single-threaded compile)."
- fi
- make ${MAKE_PARALLEL} || (echo "Could not make GMP" && exit 1)
- make check || (echo "Tests for GMP failed!" && exit 1)
- sudo make install || (echo "Could not install gmp to /usr/" && exit 1)
- cd ..
- rm -r gmp-${GMP_VERSION}
-}
 # check for operating system
 os=""
-if [ "$(uname)" = "Darwin" ]; then
+if [ "$(uname)" == "Darwin" ]; then
   os="mac"
-elif [ "$(expr substr $(uname -s) 1 5)" = "Linux" ]; then
+elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
   os="linux"
-elif [ "$(uname)" = "FreeBSD" ]; then
-  os="FreeBSD"
 else
   echo "Unsupported operating system. This script only works on Linux and macOS."
   exit 2
-fi
-
-is_mac_m1=
-if [ "$os" = "mac" ] && [ "$arch" = "arm64" ]; then
-	is_mac_m1 = "y"
-	echo "Apple arm64 silicon detected."
 fi
 
 # check that JAVA_INC is given
 if [ $# -eq 0 ]; then
 	echo "Missing Java include argument"
 	echo "Please specify path of your JDK 'include' directory as first argument"
-	if [ "$os" = "linux" ]; then
+	if [ $os == "linux" ]; then
     echo "For example: ./install_fast_mcljava_linux_mac.sh /usr/lib/jvm/java-8-openjdk-amd64/include"
-  elif [ "$os" = "FreeBSD" ]; then
-	echo "For example: ./install_fast_mcljava_linux_mac.sh  /usr/local/openjdk17/include/"
   else # mac os
     echo "For example: ./install_fast_mcljava_linux_mac.sh /Library/Java/JavaVirtualMachines/openjdk-13.0.1.jdk/Contents/Home/include"
     echo "For your system, it's probably: "
@@ -71,73 +28,38 @@ if [ $# -eq 0 ]; then
   fi
 	exit 1
 fi
-no_gmp_fast_compiler_flags=
-if [ -z ${2+x} ]; then
-	echo "Skipping from-source gmp install and fast compiler flags. Re-run this script with a second parameter to clone and build gmp from source.";
-	no_gmp_fast_compiler_flags=y
-else
-	if [ -z $is_mac_m1 ]; then
-		echo "Building gmp from source for optimal performance.";
-		cd /tmp
-		gmp_from_source
-	else
-		echo "Currently, the mcl build system does not allow linking a from-source GMP on mac. Skipping GMP build.";
-		no_gmp_fast_compiler_flags=y
-	fi
-fi
 
 java_inc=$1
 
 (
-  echo "----- Cloning mcl from https://github.com/WorldofJARcraft/mcl.git -----"
+  echo "----- Cloning mcl from https://github.com/herumi/mcl.git -----"
   cd /tmp
   git clone https://github.com/herumi/mcl.git
   cd mcl
   git checkout $mcl_version || exit
   echo "----- Deleting currently installed version of mcl -----"
-  if [ $os = "linux" ] || [ $os = "FreeBSD" ]; then
+  if [ $os == "linux" ]; then
     sudo rm /usr/lib/libmcljava.so
   else # mac os
     mkdir -p ~/Library/Java/Extensions/ #check that this is included here: System.out.println(System.getProperty("java.library.path"));
 	  rm ~/Library/Java/Extensions/libmcljava.dylib
   fi
   echo "----- Building mcl -----"
-
-  if [ -z $is_mac_m1 ] && [ -z $no_gmp_fast_compiler_flags ]; then
-    mkdir build 2>/dev/null
-    cd build
-    cmake .. -DCMAKE_C_FLAGS="${C_TUNING_FLAGS}" -DCMAKE_CXX_FLAGS="${C_TUNING_FLAGS}" -DMCL_STATIC_LIB="ON" || exit $?
-    cmake --build . || exit $?
-    cd ..
-    export MCL_LIBDIR=$(pwd)/build/lib
-  else
-    make -j $(nproc) || exit $? # cmake is currently broken on Mac M1
-  fi
-
+  make -j4 || exit # build mcl library
   echo "----- Building mcl java bindings and running tests -----"
   echo "----- Java include path: $java_inc -----"
   cd ffi/java
-  if [ -z $is_mac_m1 ] && [ -z $no_gmp_fast_compiler_flags ]; then
-    mkdir build 2>/dev/null
-    cd build
-    export JAVA_HOME=$1/../
-    if [ -z ${2+x} ]; then
-      cmake .. -DMCL_LINK_DIR=${MCL_LIBDIR} -DCMAKE_CXX_FLAGS="${C_TUNING_FLAGS} -I /usr/local/include" || exit $?
-    else
-      cmake .. -DMCL_LINK_DIR=${MCL_LIBDIR} -DCMAKE_CXX_FLAGS="${C_TUNING_FLAGS} -I /usr/local/include" -DGMP_LINK_DIR=/usr/local/lib || exit $?
-    fi
-    cmake --build . --target mcljava -v || exit $?
-  else
-    make test_mcl JAVA_INC=-I$java_inc || exit $? # CMake-based solution might not work on M1
-  fi
+  make test_mcl JAVA_INC=-I$java_inc || exit # build java bindings, set include manually
   echo "----- Copying mcl java shared library to /usr/lib/ -----"
-  if [ $os = "linux" ] || [ $os = "FreeBSD" ]; then
-    sudo cp libmcljava.so /usr/lib/
+  cd ../..
+  if [ $os == "linux" ]; then
+    sudo cp lib/libmcljava.so /usr/lib/
   else # mac os
     mkdir -p ~/Library/Java/Extensions/ #check that this is included here: System.out.println(System.getProperty("java.library.path"));
-	  cp libmcljava.dylib ~/Library/Java/Extensions/
+	  cp lib/libmcljava.dylib ~/Library/Java/Extensions/
   fi
   echo "----- Installation finished successfully. Deleting mcl repository folder -----"
-  rm -rf /tmp/mcl
+  cd ..
+  rm -rf mcl
   echo "----- Done -----"
 ) || { echo "----- Failed installation. -----"; rm -rf /tmp/mcl; exit 3; }

--- a/scripts/install_fast_mcljava_linux_mac.sh
+++ b/scripts/install_fast_mcljava_linux_mac.sh
@@ -90,7 +90,7 @@ java_inc=$1
   echo "----- Building mcl -----"
   mkdir build 2>/dev/null
   cd build
-  cmake .. -DCMAKE_C_FLAGS=${C_TUNING_FLAGS} -DCMAKE_CXX_FLAGS=${C_TUNING_FLAGS} -DMCL_STATIC_LIB="ON" 
+  cmake .. -DCMAKE_C_FLAGS="${C_TUNING_FLAGS}" -DCMAKE_CXX_FLAGS="${C_TUNING_FLAGS}" -DMCL_STATIC_LIB="ON" 
   cmake --build .
   cd ..
   export MCL_LIBDIR=$(pwd)/build/lib

--- a/scripts/install_fast_mcljava_linux_mac.sh
+++ b/scripts/install_fast_mcljava_linux_mac.sh
@@ -22,7 +22,13 @@ gmp_from_source(){
  rm gmp-${GMP_VERSION}.tar
  cd gmp-${GMP_VERSION}
  ./configure --enable-shared --enable-static --enable-cxx || (echo "Could not determine a GMP configuration" && exit 1)
- make -j $(nproc) || (echo "Could not make GMP" && exit 1)
+ MAKE_PARALLEL=""
+ if command -v nproc &>/dev/null; then
+	 MAKA_PARALLEL="-j $(nproc)"
+ else
+	 echo "nproc was not found on your system - defaulting to default make behavior (usually single-threaded compile)."
+ fi
+ make ${MAKE_PARALLEL} || (echo "Could not make GMP" && exit 1)
  make check || (echo "Tests for GMP failed!" && exit 1)
  sudo make install || (echo "Could not install gmp to /usr/" && exit 1)
  cd ..

--- a/scripts/install_fast_mcljava_linux_mac.sh
+++ b/scripts/install_fast_mcljava_linux_mac.sh
@@ -51,9 +51,9 @@ fi
 if [ $# -eq 0 ]; then
 	echo "Missing Java include argument"
 	echo "Please specify path of your JDK 'include' directory as first argument"
-	if [ $os == "linux" ]; then
+	if [ "$os" = "linux" ]; then
     echo "For example: ./install_fast_mcljava_linux_mac.sh /usr/lib/jvm/java-8-openjdk-amd64/include"
-  elif [ $os == "FreeBSD" ]; then
+  elif [ "$os" = "FreeBSD" ]; then
 	echo "For example: ./install_fast_mcljava_linux_mac.sh  /usr/local/openjdk17/include/"
   else # mac os
     echo "For example: ./install_fast_mcljava_linux_mac.sh /Library/Java/JavaVirtualMachines/openjdk-13.0.1.jdk/Contents/Home/include"
@@ -105,7 +105,7 @@ java_inc=$1
   else
 	  cmake .. -DMCL_LINK_DIR=${MCL_LIBDIR} -DCMAKE_CXX_FLAGS="${C_TUNING_FLAGS} -I /usr/local/include" -DGMP_LINK_DIR=/usr/local/lib
   fi
-  cmake --build . -v
+  cmake --build . --target mcljava -v
   echo "----- Copying mcl java shared library to /usr/lib/ -----"
   if [ $os = "linux" ] || [ $os = "FreeBSD" ]; then
     sudo cp libmcljava.so /usr/lib/
@@ -114,6 +114,6 @@ java_inc=$1
 	  cp libmcljava.dylib ~/Library/Java/Extensions/
   fi
   echo "----- Installation finished successfully. Deleting mcl repository folder -----"
-  rm -r /tmp/mcl
+  rm -rf /tmp/mcl
   echo "----- Done -----"
 ) || { echo "----- Failed installation. -----"; rm -rf /tmp/mcl; exit 3; }

--- a/scripts/install_fast_mcljava_linux_mac.sh
+++ b/scripts/install_fast_mcljava_linux_mac.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-mcl_version="45f4504244f535a55cd5b2d19bf01eee86094cf3"
+mcl_version="8591dd0158f33e265e6e6210b62d2af4494d6c50"
 # exit immediately on error
 set -e
 
@@ -13,7 +13,7 @@ gmp_from_source(){
  cd gmp-${GMP_VERSION}
  ./configure --enable-shared --enable-static --enable-cxx || (echo "Could not determine a GMP configuration" && exit 1)
  make -j $(nproc) || (echo "Could not make GMP" && exit 1)
- #make check || (echo "Tests for GMP failed!" && exit 1)
+ make check || (echo "Tests for GMP failed!" && exit 1)
  sudo make install || (echo "Could not install gmp to /usr/" && exit 1)
  cd ..
  rm -r gmp-${GMP_VERSION}
@@ -55,7 +55,7 @@ fi
 java_inc=$1
 
 (
-  echo "----- Cloning mcl from https://github.com/WorldofJARcraft/mcl.git -----"
+  echo "----- Cloning mcl from https://github.com/herumi/mcl.git -----"
   cd /tmp
   git clone https://github.com/herumi/mcl.git
   cd mcl
@@ -85,8 +85,8 @@ java_inc=$1
   else
 	  cmake .. -DMCL_LINK_DIR=${MCL_LIBDIR} -DCMAKE_C_FLAGS="-march=native -mtune=native" -DCMAKE_CXX_FLAGS="-march=native -mtune=native" -DGMP_LINK_DIR=/usr/local/lib
 	  echo cmake .. -DMCL_LINK_DIR=${MCL_LIBDIR} -DCMAKE_C_FLAGS="-march=native -mtune=native" -DCMAKE_CXX_FLAGS="-march=native -mtune=native" 
-  cmake --build . -v
   fi
+  cmake --build . -v
   echo "----- Copying mcl java shared library to /usr/lib/ -----"
   if [ $os == "linux" ]; then
     sudo cp libmcljava.so /usr/lib/

--- a/scripts/install_fast_mcljava_linux_mac.sh
+++ b/scripts/install_fast_mcljava_linux_mac.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-mcl_version="8591dd0158f33e265e6e6210b62d2af4494d6c50"
+mcl_version="5833b40a392ea22ecb086f95055865d3ab1e94f8"
 # exit immediately on error
 set -e
 
@@ -75,9 +75,9 @@ fi
 java_inc=$1
 
 (
-  echo "----- Cloning mcl from https://github.com/herumi/mcl.git -----"
+  echo "----- Cloning mcl from https://github.com/WorldofJARcraft/mcl.git -----"
   cd /tmp
-  git clone https://github.com/herumi/mcl.git
+  git clone https://github.com/WorldofJARcraft/mcl.git
   cd mcl
   git checkout $mcl_version || exit
   echo "----- Deleting currently installed version of mcl -----"

--- a/scripts/install_mcljava_with_optimized_gmp.sh
+++ b/scripts/install_mcljava_with_optimized_gmp.sh
@@ -26,7 +26,7 @@ gmp_from_source(){
  ./configure --enable-shared --enable-static --enable-cxx || (echo "Could not determine a GMP configuration" && exit 1)
  MAKE_PARALLEL=""
  if command -v nproc &>/dev/null; then
-	 MAKA_PARALLEL="-j $(nproc)"
+	 MAKE_PARALLEL="-j $(nproc)"
  else
 	 echo "nproc was not found on your system - defaulting to default make behavior (usually single-threaded compile)."
  fi
@@ -54,21 +54,19 @@ if [ $# -eq 0 ]; then
 	echo "Missing Java include argument"
 	echo "Please specify path of your JDK 'include' directory as first argument"
 	if [ "$os" = "linux" ]; then
-    echo "For example: ./install_fast_mcljava_linux_mac.sh /usr/lib/jvm/java-8-openjdk-amd64/include"
+    echo "For example: $0 /usr/lib/jvm/java-8-openjdk-amd64/include"
   elif [ "$os" = "FreeBSD" ]; then
-	echo "For example: ./install_fast_mcljava_linux_mac.sh  /usr/local/openjdk17/include/"
+	echo "For example: $0  /usr/local/openjdk17/include/"
   else # mac os
-    echo "For example: ./install_fast_mcljava_linux_mac.sh /Library/Java/JavaVirtualMachines/openjdk-13.0.1.jdk/Contents/Home/include"
+    echo "For example: $0 /Library/Java/JavaVirtualMachines/openjdk-13.0.1.jdk/Contents/Home/include"
     echo "For your system, it's probably: "
     javahome=$(/usr/libexec/java_home)
-    echo ./install_fast_mcljava_linux_mac.sh $javahome/include
+    echo $0 $javahome/include
   fi
 	exit 1
 fi
-no_gmp_fast_compiler_flags=
 if [ -z ${2+x} ]; then
-	echo "Skipping from-source gmp install and fast compiler flags. Re-run this script with a second parameter to clone and build gmp from source.";
-	no_gmp_fast_compiler_flags=y
+	echo "Skipping from-source gmp install, assuming that GMP is already installed. To custom-build GMP for your system (with performance gains), call this script with 'gmp' as the second parameter."
 else
 	echo "Building gmp from source for optimal performance.";
 	cd /tmp
@@ -78,7 +76,7 @@ fi
 java_inc=$1
 
 (
-  echo "----- Cloning mcl from https://github.com/WorldofJARcraft/mcl.git -----"
+  echo "----- Cloning mcl from https://github.com/herumi/mcl.git -----"
   cd /tmp
   git clone https://github.com/herumi/mcl.git
   cd mcl

--- a/scripts/install_mcljava_with_optimized_gmp.sh
+++ b/scripts/install_mcljava_with_optimized_gmp.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env sh
+mcl_version="ae1c67a819a81fd645a544d5fb420b980b89816a"
+# exit immediately on error
+set -e
+
+C_TUNING_FLAGS="-march=native -mtune=native"
+
+arch="$(uname -m)"
+
+if [ "$arch" = "arm64" ] || [ "$arch" = "aarch64" ]; then
+  if command -v clang &>/dev/null; then
+    # clang exists and we run on arm64 - clang might be chosen as compiler by CMake, and on this arch, it does not support -march=native
+    # this flag works with both gcc and clang on aarch64, however, and should have the same effect - use it instead
+    C_TUNING_FLAGS="-mcpu=native"
+  fi
+fi
+
+GMP_VERSION=6.2.1
+gmp_from_source(){
+ echo "Cloning GNU gmp."
+ curl https://gmplib.org/download/gmp/gmp-${GMP_VERSION}.tar.xz > gmp-${GMP_VERSION}.tar.xz || (echo "Error downloading GMP" && exit 1)
+ unxz gmp-${GMP_VERSION}.tar.xz || (echo "Could not extract .xz archive - make sure you have unxz installed." && exit 1)
+ tar -xvf gmp-${GMP_VERSION}.tar || (echo "Could not untar the gmp tree." && exit 1)
+ rm gmp-${GMP_VERSION}.tar
+ cd gmp-${GMP_VERSION}
+ ./configure --enable-shared --enable-static --enable-cxx || (echo "Could not determine a GMP configuration" && exit 1)
+ MAKE_PARALLEL=""
+ if command -v nproc &>/dev/null; then
+	 MAKA_PARALLEL="-j $(nproc)"
+ else
+	 echo "nproc was not found on your system - defaulting to default make behavior (usually single-threaded compile)."
+ fi
+ make ${MAKE_PARALLEL} || (echo "Could not make GMP" && exit 1)
+ make check || (echo "Tests for GMP failed!" && exit 1)
+ sudo make install || (echo "Could not install gmp to /usr/" && exit 1)
+ cd ..
+ rm -rf gmp-${GMP_VERSION}
+}
+# check for operating system
+os=""
+if [ "$(uname)" = "Darwin" ]; then
+  os="mac"
+elif [ "$(expr substr $(uname -s) 1 5)" = "Linux" ]; then
+  os="linux"
+elif [ "$(uname)" = "FreeBSD" ]; then
+  os="FreeBSD"
+else
+  echo "Unsupported operating system. This script only works on Linux and macOS."
+  exit 2
+fi
+
+# check that JAVA_INC is given
+if [ $# -eq 0 ]; then
+	echo "Missing Java include argument"
+	echo "Please specify path of your JDK 'include' directory as first argument"
+	if [ "$os" = "linux" ]; then
+    echo "For example: ./install_fast_mcljava_linux_mac.sh /usr/lib/jvm/java-8-openjdk-amd64/include"
+  elif [ "$os" = "FreeBSD" ]; then
+	echo "For example: ./install_fast_mcljava_linux_mac.sh  /usr/local/openjdk17/include/"
+  else # mac os
+    echo "For example: ./install_fast_mcljava_linux_mac.sh /Library/Java/JavaVirtualMachines/openjdk-13.0.1.jdk/Contents/Home/include"
+    echo "For your system, it's probably: "
+    javahome=$(/usr/libexec/java_home)
+    echo ./install_fast_mcljava_linux_mac.sh $javahome/include
+  fi
+	exit 1
+fi
+no_gmp_fast_compiler_flags=
+if [ -z ${2+x} ]; then
+	echo "Skipping from-source gmp install and fast compiler flags. Re-run this script with a second parameter to clone and build gmp from source.";
+	no_gmp_fast_compiler_flags=y
+else
+	echo "Building gmp from source for optimal performance.";
+	cd /tmp
+	gmp_from_source
+fi
+
+java_inc=$1
+
+(
+  echo "----- Cloning mcl from https://github.com/WorldofJARcraft/mcl.git -----"
+  cd /tmp
+  git clone https://github.com/herumi/mcl.git
+  cd mcl
+  git checkout $mcl_version || exit
+  echo "----- Deleting currently installed version of mcl -----"
+  if [ $os = "linux" ] || [ $os = "FreeBSD" ]; then
+    sudo rm /usr/lib/libmcljava.so
+  else # mac os
+    mkdir -p ~/Library/Java/Extensions/ #check that this is included here: System.out.println(System.getProperty("java.library.path"));
+	  rm ~/Library/Java/Extensions/libmcljava.dylib
+  fi
+  echo "----- Building mcl -----"
+
+  mkdir build 2>/dev/null
+  cd build
+  cmake .. -DCMAKE_C_FLAGS="${C_TUNING_FLAGS}" -DCMAKE_CXX_FLAGS="${C_TUNING_FLAGS}" -DMCL_STATIC_LIB="ON" || exit $?
+  cmake --build . || exit $?
+  cd ..
+  export MCL_LIBDIR=$(pwd)/build/lib
+  echo "----- Building mcl java bindings and running tests -----"
+  echo "----- Java include path: $java_inc -----"
+  cd ffi/java
+  mkdir build 2>/dev/null
+  cd build
+  export JAVA_HOME=$1/../
+  cmake .. -DMCL_LINK_DIR=${MCL_LIBDIR} -DCMAKE_CXX_FLAGS="${C_TUNING_FLAGS} -I /usr/local/include" -DGMP_LINK_DIR=/usr/local/lib || exit $?
+  cmake --build . --target mcljava || exit $?
+  echo "----- Copying mcl java shared library to /usr/lib/ -----"
+  if [ $os = "linux" ] || [ $os = "FreeBSD" ]; then
+    sudo cp libmcljava.so /usr/lib/
+  else # mac os
+    mkdir -p ~/Library/Java/Extensions/ #check that this is included here: System.out.println(System.getProperty("java.library.path"));
+	  cp libmcljava.dylib ~/Library/Java/Extensions/
+  fi
+  echo "----- Installation finished successfully. Deleting mcl repository folder -----"
+  rm -rf /tmp/mcl
+  echo "----- Done -----"
+) || { echo "----- Failed installation. -----"; rm -rf /tmp/mcl; exit 3; }


### PR DESCRIPTION
# Summary
The `install_fast_mcljava_linux_mac.sh` script - as shipped by mclwrap currently - relies on the libgmp that is provided by the system. Because this libgmp has to work on various CPUs, it cannot be tailored to the CPU it is currently running on, and will restrict itself to using portable instructions instead of utilizing everything the current CPU supports (e.g. AVX, AES-NI, etc.).  
Since the script aims at generating a library for the local machine only, I extended it to be able to:
- use machine-dependent optimization for mcl and libmcljava itself (-march=native)
- compile gmp from source with highest possible optimization to the local CPU (controlled by a new parameter, i.e. this has to be enabled by the user).

# What I tested
- mclwrap's tests still work on my Ubuntu 20.04 LTS test system and in the GitHub actions
- libmcljava compiles with and without also compiling GMP from source
- my application which uses mclwrap still works with both versions of libmcljava

# What I did not test
- I did not test the script on a Mac, compiling gmp might require extra dependencies (e.g. m4)
- I did not measure how much performance is actually gained by this